### PR TITLE
Optimization for the devbookclub.org site when viewed on mobiles

### DIFF
--- a/source/_views/layout.html
+++ b/source/_views/layout.html
@@ -6,7 +6,7 @@
 {% block head_meta %}
 <meta name="robots" content="noindex, follow">
 {% endblock %}
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 <meta name="description" content="">
 <meta name="author" content="">
 <!-- Le styles -->

--- a/source/about.md
+++ b/source/about.md
@@ -21,6 +21,6 @@ Each session is held via Google Plus Hangouts on Air on the official Dev Book Cl
 
 ## Code of Conduct
 
-Dev Book Club prides itself on being a resource for developers of all walks of life. Our group is open to anyone and everyone with a passion for technology and learning, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or preference for Vim, Emacs, or any other editor. To ensure everyone has an amazing experience, we, the organizers and hosts of Dev Book Club, will not tolerate any harassment or sexually charged language directed at any participants. The organizers will deal with each ovserved or reported situation on a case-by-case basis and reserve the right to expel offenders from the discussion and/or the group.
+Dev Book Club prides itself on being a resource for developers of all walks of life. Our group is open to anyone and everyone with a passion for technology and learning, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or preference for Vim, Emacs, or any other editor. To ensure everyone has an amazing experience, we, the organizers and hosts of Dev Book Club, will not tolerate any harassment or sexually charged language directed at any participants. The organizers will deal with each observed or reported situation on a case-by-case basis and reserve the right to expel offenders from the discussion and/or the group.
 
 For more information see our [full Code of Conduct](/code-of-conduct).

--- a/source/css/custom.css
+++ b/source/css/custom.css
@@ -767,8 +767,11 @@ ul.social-links>li.pinterest-link:hover {
 	list-style:none
 }
 .vuzz-pricing-table>div {
+	/*
+	// Not valid CSS, and overwritten below in any case
 	border-top:#666;
 	3px solid;
+	*/
 	margin-right:2%;
 	list-style:none;
 	text-shadow:none;
@@ -1496,4 +1499,20 @@ a:hover,a:focus {
 }
 .smallspacetop {
 	margin-top: 10px;
+}
+
+@media (max-width: 320px) {
+
+	.youTubeVideo{
+		max-width:100%;
+	}
+
+}
+
+@media (max-width: 768px) {
+
+	.youTubeVideo{
+		max-width:560px;
+	}
+
 }

--- a/source/css/custom.css
+++ b/source/css/custom.css
@@ -1117,6 +1117,8 @@ ul.social-links>li.pinterest-link:hover {
 	padding:10px;
 	color:#333;
 	margin-right:10px;
+    margin-bottom:10px;
+    display:inline-block;
 }
 .spacebot {
 	margin-bottom:20px;
@@ -1501,18 +1503,21 @@ a:hover,a:focus {
 	margin-top: 10px;
 }
 
-@media (max-width: 320px) {
-
-	.youTubeVideo{
-		max-width:100%;
-	}
-
+/*
+iFrame fluid video css from http://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php
+*/
+.youTubeVideo{
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 */
+    padding-top: 25px;
+    height: 0;
 }
 
-@media (max-width: 768px) {
-
-	.youTubeVideo{
-		max-width:560px;
-	}
-
+.youTubeVideo iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }
+

--- a/source/index.html
+++ b/source/index.html
@@ -20,7 +20,7 @@ use:
                 </p>
                 <p>{{ discussion.blocks.content | raw }}</p>
                 <div class="discussion-video spacetop">
-                    <iframe width="560" height="315" src="//www.youtube.com/embed/{{ discussion.youtube_id }}" frameborder="0" allowfullscreen></iframe>
+                    <iframe class="youTubeVideo" height="315" src="//www.youtube.com/embed/{{ discussion.youtube_id }}" frameborder="0" allowfullscreen></iframe>
                 </div>
             </div>
             {% endfor %}

--- a/source/index.html
+++ b/source/index.html
@@ -19,8 +19,8 @@ use:
                 <a href="http://amzn.com/{{ discussion.amazonid }}" class="metablog"><i class="icon icon-align-left"></i> {{ discussion.book }} </a>
                 </p>
                 <p>{{ discussion.blocks.content | raw }}</p>
-                <div class="discussion-video spacetop">
-                    <iframe class="youTubeVideo" height="315" src="//www.youtube.com/embed/{{ discussion.youtube_id }}" frameborder="0" allowfullscreen></iframe>
+                <div class="discussion-video spacetop youTubeVideo">
+                    <iframe height="315" src="//www.youtube.com/embed/{{ discussion.youtube_id }}" frameborder="0" allowfullscreen></iframe>
                 </div>
             </div>
             {% endfor %}


### PR DESCRIPTION
YouTube videos in the discussion loop were wider than the screen on mobiles. This pull request resizes the container around the iFrame contextually so they fit for phones, and when expanded to tablets, monitors etc.

Also fixed the labels (date and book) in each discussion when viewed on a mobile.

Corrected a minor spelling mistake in the Code of Conduct (ovserved to observed)
